### PR TITLE
Fix the logo URL

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,7 @@
             {% if current_path == "/" %}
             <img src="{{ config.extra.logo | safe }}" alt="" />
 
-            {% else %}<a href="/">
+            {% else %}<a href="{{ config.base_url }}">
             <img src="{{ config.extra.logo | safe }}" alt="" />
                 </a>
             {% endif %}


### PR DESCRIPTION
Currently, clicking the logo doesn't go to the BASE_URL. This fixes it.