### PR TITLE
2 fixes, some cleanup and improved handling of sections with no pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As you may have heard Zola is quite flexible :) So, the scenario below is one of
 
 1. Fork the repo and replace demo-content inside content folder with yours. But take a look to _index.md files. It contains `title` and when you want to have anchor right of your headers add `insert_anchor_links = "right"` to each index. `theme.toml`, screenshot and readme may be deleted too. 
 2. Inside `config.toml` change URL and title on your own. In extra section you can specify path to your GitHub API for version below the logo on nav, favicon and logo itself. Or just remove the lines if you don't need it. Also, you can configure or turn on some additional settings related to Zola. [Specification is here](https://www.getzola.org/documentation/getting-started/configuration/).
-3. In sass/_variables.scss you may change font, color or backgound if you want. 
+3. In sass/_variables.scss you may change font, color or background if you want.
 4. Almost done. Now, you should decide how you want to build and where will be hosted your website. You can build it locally and upload to somewhere. Or build in GitHub Actions and host on GitHub Pages / Netlify / CloudFlare Pages / AnyS3CloudStorage. [Howto for GitHub Pages](https://www.getzola.org/documentation/deployment/github-pages/). [My example](https://github.com/o365hq/o365hq.com/blob/main/.github/workflows/main.yml) of GitHub workflow with 2-steps build (the first checks for links and spelling errors, the second uploads to Azure). [Dockerfile](https://github.com/codeandmedia/zola_docsascode_theme/blob/master/Dockerfile) to make Docker image.
 
 Enjoy your docs!

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,19 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="{{ get_url(path="main.css") | safe }}">
-    {% if config.extra.favicon %}
-        {% set _favicon = config.extra.favicon %}
-        {% if (_favicon is starting_with("http")) == false %}
-            {% set _favicon = get_url(path=config.extra.favicon) %}
-        {% endif %}
+    {% if config.extra.favicon -%}
+        {% set _favicon = config.extra.favicon -%}
+        {% if (_favicon is starting_with("http")) == false -%}
+            {% set _favicon = get_url(path=config.extra.favicon) -%}
+        {% endif -%}
         <link rel="icon" href="{{ _favicon | safe }}">
-    {% endif %}
+    {% endif -%}
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
     <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 </head>
 <body>
 
-{% if config.extra.release %}
+{% if config.extra.release -%}
     <script>
         fetch('{{ config.extra.release | safe }}')
             .then((response) => {
@@ -27,37 +27,38 @@
                 release.innerHTML = `<a href='${html_url}'>${release_name}</a>`;
             });
     </script>
-{% endif %}
+{% endif -%}
 <main>
 
-    {% block nav %}
+    {% block nav -%}
 
         <nav>
-            {% if config.extra.logo %}
-                {% set _logo = config.extra.logo %}
-                {% if (_logo is starting_with("http")) == false %}
-                    {% set _logo = get_url(path=config.extra.logo) %}
-                {% endif %}
-                {% if current_path == "/" and not config.extra.easydocs_logo_always_clickable %}
+            {% if config.extra.logo -%}
+                {% set _logo = config.extra.logo -%}
+                {% if (_logo is starting_with("http")) == false -%}
+                    {% set _logo = get_url(path=config.extra.logo) -%}
+                {% endif -%}
+                {% if current_path == "/" and not config.extra.easydocs_logo_always_clickable -%}
                     <img src="{{ _logo | safe }}" alt=""/>
-                {% else %}<a href="{{ config.base_url }}">
-                    <img src="{{ _logo | safe }}" alt=""/>
-                </a>
-                {% endif %}
+                {% else -%}
+                    <a href="{{ config.base_url }}">
+                        <img src="{{ _logo | safe }}" alt=""/>
+                    </a>
+                {% endif -%}
 
-            {% else %}
+            {% else -%}
                 <h1><a href="{{ config.base_url }}">{{ config.title }}</a></h1>
-            {% endif %}
+            {% endif -%}
 
-            {% if config.extra.release %}
+            {% if config.extra.release -%}
                 <div id="release"></div>
-            {% endif %}
+            {% endif -%}
 
             <a href="javascript:void(0);" onclick="burger()" id="mobile" class="ms-Icon--GlobalNavButton"></a>
             <div id="trees">
-                {% set section_ = get_section(path="_index.md") %}
-                {% for p in section_.subsections %}
-                    {% set subsection = get_section(path=p) %}
+                {% set section_ = get_section(path="_index.md") -%}
+                {% for p in section_.subsections -%}
+                    {% set subsection = get_section(path=p) -%}
 
 
                     <input class="tree-toggle" type="checkbox" id="{{ subsection.title | slugify }}"
@@ -66,56 +67,56 @@
                            for="{{ subsection.title | slugify }}">{{ subsection.title }}</label>
 
                     <ul class="subtree">
-                        {% for page in subsection.pages %}
+                        {% for page in subsection.pages -%}
                             <li {% if current_path == page.path %}class="active"{% endif %}>
                                 <a href="{{ page.permalink | safe }}">{{ page.title }}</a>
                             </li>
 
-                            {% if page.toc %}
+                            {% if page.toc -%}
 
-                                {% if current_path == page.path %}
+                                {% if current_path == page.path -%}
 
-                                    {% set_global header_count = 0 %}
-                                    {% for h2 in page.toc %}
-                                        {% set_global header_count = header_count + 1 %}
-                                        {% for h3 in h2.children %}
-                                            {% set_global header_count = header_count + 1 %}
-                                            {% for h4 in h3.children %}
-                                                {% set_global header_count = header_count + 1 %}
-                                            {% endfor %}
-                                        {% endfor %}
-                                    {% endfor %}
+                                    {% set_global header_count = 0 -%}
+                                    {% for h2 in page.toc -%}
+                                        {% set_global header_count = header_count + 1 -%}
+                                        {% for h3 in h2.children -%}
+                                            {% set_global header_count = header_count + 1 -%}
+                                            {% for h4 in h3.children -%}
+                                                {% set_global header_count = header_count + 1 -%}
+                                            {% endfor -%}
+                                        {% endfor -%}
+                                    {% endfor -%}
 
-                                    {% if header_count > 4 %}
+                                    {% if header_count > 4 -%}
                                         <ul id="toc">
-                                            {% for h2 in page.toc %}
+                                            {% for h2 in page.toc -%}
                                                 <li><a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
-                                                    {% if h2.children %}
+                                                    {% if h2.children -%}
                                                         <ul>
-                                                            {% for h3 in h2.children %}
+                                                            {% for h3 in h2.children -%}
                                                                 <li>
                                                                     <a href="{{ h3.permalink | safe }}">{{ h3.title }}</a>
                                                                 </li>
-                                                            {% endfor %}
+                                                            {% endfor -%}
                                                         </ul>
-                                                    {% endif %}
+                                                    {% endif -%}
                                                 </li>
-                                            {% endfor %}
+                                            {% endfor -%}
                                         </ul>
-                                    {% endif %}
+                                    {% endif -%}
 
-                                {% endif %}
-                            {% endif %}
-                        {% endfor %}
+                                {% endif -%}
+                            {% endif -%}
+                        {% endfor -%}
                     </ul>
-                {% endfor %}
+                {% endfor -%}
             </div>
         </nav>
-    {% endblock nav %}
+    {% endblock nav -%}
 
     <article>
 
-        {% if config.build_search_index %}
+        {% if config.build_search_index -%}
             <div id="on_right">
                 <span id="search-ico" class="ms-Icon--Search"></span>
             </div>
@@ -126,10 +127,10 @@
                     <ul class="search-results__items"></ul>
                 </div>
             </div>
-        {% endif %}
+        {% endif -%}
 
         <div id="wrap">
-            {% block content %}
+            {% block content -%}
                 {{ section.content | safe }}
             {% endblock content %}
         </div>
@@ -141,7 +142,7 @@
     <script type="text/javascript" src="{{ get_url(path="elasticlunr.min.js") | safe }}" defer></script>
     <script type="text/javascript" src="{{ get_url(path="search_index.en.js") | safe }}" defer></script>
     <script type="text/javascript" src="{{ get_url(path="js.js") | safe }}" defer></script>
-{% endif %}
+{% endif -%}
 
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,7 +131,11 @@
 
         <div id="wrap">
             {% block content -%}
-                {{ section.content | safe }}
+                {%- if section.word_count > 0 -%}
+                    {{ section.content |safe }}
+                {%- else -%}
+                    {%- include "sec_toc_2_level.html" -%}
+                {% endif -%}
             {% endblock content %}
         </div>
 

--- a/templates/sec_toc_2_level.html
+++ b/templates/sec_toc_2_level.html
@@ -1,0 +1,20 @@
+<h2>Table of Contents</h2>
+{% if section.subsections -%}
+    <ul>
+        {% for subsec in section.subsections -%}
+            {% set sec_ = get_section(path=subsec) -%}
+            <li>
+                <a href="{{ sec_.permalink | safe }}">{{ sec_.title }}</a>
+                {% if sec_.pages -%}
+                    <ul>
+                        {% for page_ in sec_.pages -%}
+                            <li><a href="{{ page_.permalink | safe }}">{{ page_.title }}</a></li>
+                        {% endfor %}
+                    </ul>
+                {% endif -%}
+            </li>
+        {% endfor %}
+    </ul>
+{% else -%}
+    <h3> No Sections Found </h3>
+{% endif -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -6,14 +6,16 @@
     {% if section.word_count > 0 -%}
         {{ section.content }}
     {% else -%}
-        <h1 class="title">
-            {{ section.title }}
-        </h1>
-        Pages:
+        <h2 class="title"> {{ section.title }} </h2>
+        <h3>Pages:</h3>
         <ul>
-            {% for page in section.pages -%}
-                <li><a href="{{ page.permalink | safe }}">{{ page.title }}</a></li>
-            {% endfor -%}
+            {% if section.pages -%}
+                {% for page in section.pages -%}
+                    <li><a href="{{ page.permalink | safe }}">{{ page.title }}</a></li>
+                {% endfor -%}
+            {% else -%}
+                <li>No pages</li>
+            {% endif %}
         </ul>
     {% endif -%}
 {% endblock content %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -7,6 +7,17 @@
         {{ section.content }}
     {% else -%}
         <h2 class="title"> {{ section.title }} </h2>
+
+        {% if section.subsections -%}
+            <h3>Subsections:</h3>
+            <ul>
+                {% for subsec in section.subsections -%}
+                    {% set sec_ = get_section(path=subsec) -%}
+                    <li><a href="{{ sec_.permalink | safe }}">{{ sec_.title }}</a></li>
+                {% endfor %}
+            </ul>
+        {% endif -%}
+
         <h3>Pages:</h3>
         <ul>
             {% if section.pages -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -2,21 +2,20 @@
 
 {% block title %} {{ config.title }} | {{ section.title }} {% endblock title %}
 
-
 {% block content %}
-    {% if section.word_count > 0 %}
+    {% if section.word_count > 0 -%}
         {{ section.content }}
-    {% else %}
+    {% else -%}
         <h1 class="title">
             {{ section.title }}
         </h1>
         Pages:
         <ul>
-            {% for page in section.pages %}
+            {% for page in section.pages -%}
                 <li><a href="{{ page.permalink | safe }}">{{ page.title }}</a></li>
-            {% endfor %}
+            {% endfor -%}
         </ul>
-    {% endif %}
+    {% endif -%}
 {% endblock content %}
 
 

--- a/templates/section.html
+++ b/templates/section.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     {% if section.word_count > 0 -%}
-        {{ section.content }}
+        {{ section.content | safe }}
     {% else -%}
         <h2 class="title"> {{ section.title }} </h2>
 


### PR DESCRIPTION
- Cleanup on templates to stop generating unnecessary white space in output html
- Add code to handle sections with no pages
- Add support for deeper structures (show subsection on section page). Useful if a subcategory becomes necessary. Doesn't affect navigation on left.
- Fix for missing use of safe filter.
- Add default landing page if one is not provided in _index.md (shows a table of contents, similar to nav on left but fully expanded because it makes searching on the page easier with "Ctrl + F" in the browser. Text in nav is often hidden and search appears to produce no results.)
- Fix typo