### PR TITLE
Add offline site support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,3 +12,10 @@ logo = "https://easydocs.codeandmedia.com/logo.svg"
 release = "https://api.github.com/repos/getzola/zola/releases/latest"
 favicon = "https://www.getzola.org/favicon.ico"
 easydocs_logo_always_clickable = false
+
+# For use with offline sites. If set to true template links are generated with the full path indcluding index.html
+# Insired by Abridge theme https://www.getzola.org/themes/abridge/
+# Notes:
+#  - Also requries the base URL to be set to the local folder where the site is stored eg. base_url = /home/user/mysite/public/
+#  - This is not portable and only works with a specific local folder
+easydocs_uglyurls = false

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,7 @@
     </script>
 {% endif -%}
 <main>
+    {# Create variable to allow appending index.html at end of links if set in config #}
     {% if not config.extra.easydocs_uglyurls -%}
         {% set _ugly_url = "" -%}
     {% else %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,10 +39,10 @@
                     {% set _logo = get_url(path=config.extra.logo) -%}
                 {% endif -%}
                 {% if current_path == "/" and not config.extra.easydocs_logo_always_clickable -%}
-                    <img src="{{ _logo | safe }}" alt=""/>
+                    <img src="{{ _logo | safe }}" alt="logo"/>
                 {% else -%}
                     <a href="{{ config.base_url }}">
-                        <img src="{{ _logo | safe }}" alt=""/>
+                        <img src="{{ _logo | safe }}" alt="logo"/>
                     </a>
                 {% endif -%}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,9 +29,13 @@
     </script>
 {% endif -%}
 <main>
+    {% if not config.extra.easydocs_uglyurls -%}
+        {% set _ugly_url = "" -%}
+    {% else %}
+        {% set _ugly_url = "index.html" -%}
+    {% endif -%}
 
-    {% block nav -%}
-
+    {%- block nav -%}
         <nav>
             {% if config.extra.logo -%}
                 {% set _logo = config.extra.logo -%}
@@ -41,13 +45,13 @@
                 {% if current_path == "/" and not config.extra.easydocs_logo_always_clickable -%}
                     <img src="{{ _logo | safe }}" alt="logo"/>
                 {% else -%}
-                    <a href="{{ config.base_url }}">
+                    <a href="{{ config.base_url }}{{ _ugly_url }}">
                         <img src="{{ _logo | safe }}" alt="logo"/>
                     </a>
                 {% endif -%}
 
             {% else -%}
-                <h1><a href="{{ config.base_url }}">{{ config.title }}</a></h1>
+                <h1><a href="{{ config.base_url }}{{ _ugly_url }}">{{ config.title }}</a></h1>
             {% endif -%}
 
             {% if config.extra.release -%}
@@ -69,7 +73,7 @@
                     <ul class="subtree">
                         {% for page in subsection.pages -%}
                             <li {% if current_path == page.path %}class="active"{% endif %}>
-                                <a href="{{ page.permalink | safe }}">{{ page.title }}</a>
+                                <a href="{{ page.permalink | safe }}{{ _ugly_url }}">{{ page.title }}</a>
                             </li>
 
                             {% if page.toc -%}
@@ -90,12 +94,19 @@
                                     {% if header_count > 4 -%}
                                         <ul id="toc">
                                             {% for h2 in page.toc -%}
-                                                <li><a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
+                                                <li><a href="
+                                                        {{ h2.permalink | safe }}{{ _ugly_url }}">{{ h2.title }}</a>
                                                     {% if h2.children -%}
                                                         <ul>
                                                             {% for h3 in h2.children -%}
                                                                 <li>
-                                                                    <a href="{{ h3.permalink | safe }}">{{ h3.title }}</a>
+                                                                    <a href="
+
+
+
+
+
+                                                                            {{ h3.permalink | safe }}{{ _ugly_url }}">{{ h3.title }}</a>
                                                                 </li>
                                                             {% endfor -%}
                                                         </ul>

--- a/templates/sec_toc_2_level.html
+++ b/templates/sec_toc_2_level.html
@@ -1,14 +1,19 @@
 <h2>Table of Contents</h2>
+{% if not config.extra.easydocs_uglyurls -%}
+    {% set _ugly_url = "" -%}
+{% else %}
+    {% set _ugly_url = "index.html" -%}
+{% endif -%}
 {% if section.subsections -%}
     <ul>
         {% for subsec in section.subsections -%}
             {% set sec_ = get_section(path=subsec) -%}
             <li>
-                <a href="{{ sec_.permalink | safe }}">{{ sec_.title }}</a>
+                <a href="{{ sec_.permalink | safe }}{{ _ugly_url }}">{{ sec_.title }}</a>
                 {% if sec_.pages -%}
                     <ul>
                         {% for page_ in sec_.pages -%}
-                            <li><a href="{{ page_.permalink | safe }}">{{ page_.title }}</a></li>
+                            <li><a href="{{ page_.permalink | safe }}{{ _ugly_url }}">{{ page_.title }}</a></li>
                         {% endfor %}
                     </ul>
                 {% endif -%}

--- a/templates/sec_toc_2_level.html
+++ b/templates/sec_toc_2_level.html
@@ -1,9 +1,4 @@
 <h2>Table of Contents</h2>
-{% if not config.extra.easydocs_uglyurls -%}
-    {% set _ugly_url = "" -%}
-{% else %}
-    {% set _ugly_url = "index.html" -%}
-{% endif -%}
 {% if section.subsections -%}
     <ul>
         {% for subsec in section.subsections -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -3,12 +3,6 @@
 {% block title %} {{ config.title }} | {{ section.title }} {% endblock title %}
 
 {% block content %}
-    {% if not config.extra.easydocs_uglyurls -%}
-        {% set _ugly_url = "" -%}
-    {% else %}
-        {% set _ugly_url = "index.html" -%}
-    {% endif -%}
-
     {% if section.word_count > 0 -%}
         {{ section.content | safe }}
     {% else -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -3,6 +3,12 @@
 {% block title %} {{ config.title }} | {{ section.title }} {% endblock title %}
 
 {% block content %}
+    {% if not config.extra.easydocs_uglyurls -%}
+        {% set _ugly_url = "" -%}
+    {% else %}
+        {% set _ugly_url = "index.html" -%}
+    {% endif -%}
+
     {% if section.word_count > 0 -%}
         {{ section.content | safe }}
     {% else -%}
@@ -13,7 +19,7 @@
             <ul>
                 {% for subsec in section.subsections -%}
                     {% set sec_ = get_section(path=subsec) -%}
-                    <li><a href="{{ sec_.permalink | safe }}">{{ sec_.title }}</a></li>
+                    <li><a href="{{ sec_.permalink | safe }}{{ _ugly_url }}">{{ sec_.title }}</a></li>
                 {% endfor %}
             </ul>
         {% endif -%}
@@ -22,7 +28,7 @@
         <ul>
             {% if section.pages -%}
                 {% for page in section.pages -%}
-                    <li><a href="{{ page.permalink | safe }}">{{ page.title }}</a></li>
+                    <li><a href="{{ page.permalink | safe }}{{ _ugly_url }}">{{ page.title }}</a></li>
                 {% endfor -%}
             {% else -%}
                 <li>No pages</li>


### PR DESCRIPTION
# Disclaimer

I know this doesn't quite match the intent of this theme but I decided to open the pull request in case you were interested in adding it. 

# Rational and use case

I use one of my sites as an offline documentation tool for me to record things I don't want to lookup again and it needs to work even when I don't have a network connection. I'd been using it for a while and got fed up of always needing to click on index.html after I click on the page I want. So I opened a [topic](https://zola.discourse.group/t/create-offline-website/1374) on the zola discourse to get help and got pointed to a the abridge them as they have a solution and while it's not perfect it's will fix my problem most of the time. Especially when I use the navigation menu on the left or the "default" table of contents on the empty index homepage. So I've implemented it in this theme because I prefer this theme for my use case.

# Documentation Update

If you do decide to add it I was wondering if I should try to document the features that have been added to readme.md? Happy to iterate on the documentation update until you're happy with it because I understand that's the first interaction a user has with the theme. Mostly because I'm not sure if there are other people who have a similar use case to mine who would benefit from not needing to reinvent the wheel.

Features that I am considering documenting (let me know if I missed any or if you would prefer leave any out):
- Offline site support
- Default landing page with table of contents
- Always clickable logo
- Missing logo shows page title in it's place
- Logo and favicon co-located file support (doesn't need to be a fully qualified url)
- Specific steps to take to add the theme as a submodule (would allow users easily benefit from any updates) NB: not replace current install instructions just provide an alternate method
- Create a demo site showing the table of content feature