### PR TITLE
Fix issue with ugly url affecting `zola serve`

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -101,13 +101,7 @@
                                                         <ul>
                                                             {% for h3 in h2.children -%}
                                                                 <li>
-                                                                    <a href="
-
-
-
-
-
-                                                                            {{ h3.permalink | safe }}{{ _ugly_url }}">{{ h3.title }}</a>
+                                                                    <a href="{{ h3.permalink | safe }}">{{ h3.title }}</a>
                                                                 </li>
                                                             {% endfor -%}
                                                         </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
 {% endif -%}
 <main>
     {# Create variable to allow appending index.html at end of links if set in config #}
-    {% if not config.extra.easydocs_uglyurls -%}
+    {% if not config.extra.easydocs_uglyurls or config.mode == "Serve" -%}
         {% set _ugly_url = "" -%}
     {% else %}
         {% set _ugly_url = "index.html" -%}


### PR DESCRIPTION
- Simple fix to disable ugly urls when using `zola serve`
- Remove of white space added in error