### PR TITLE
Allow user to control how many headings are needed before it shows in the nav

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,3 +19,6 @@ easydocs_logo_always_clickable = false
 #  - Also requries the base URL to be set to the local folder where the site is stored eg. base_url = /home/user/mysite/public/
 #  - This is not portable and only works with a specific local folder
 easydocs_uglyurls = false
+
+# Controls how many headings are needed on a page before the headings show in the navigation on the left
+easydocs_heading_threshold = 4

--- a/config.toml
+++ b/config.toml
@@ -20,5 +20,5 @@ easydocs_logo_always_clickable = false
 #  - This is not portable and only works with a specific local folder
 easydocs_uglyurls = false
 
-# Controls how many headings are needed on a page before the headings show in the navigation on the left
-easydocs_heading_threshold = 4
+# Minimum number of headings needed on a page before the headings show in the navigation on the left. Defaults to 5.
+easydocs_heading_threshold = 5

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,7 @@
 
                                 {% if current_path == page.path -%}
 
+                                    {# Count number of headers on page #}
                                     {% set_global header_count = 0 -%}
                                     {% for h2 in page.toc -%}
                                         {% set_global header_count = header_count + 1 -%}
@@ -92,7 +93,8 @@
                                         {% endfor -%}
                                     {% endfor -%}
 
-                                    {% if header_count > 4 -%}
+                                    {# Output headers if above threshold #}
+                                    {% if header_count > config.extra.easydocs_heading_threshold -%}
                                         <ul id="toc">
                                             {% for h2 in page.toc -%}
                                                 <li><a href="

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,7 +96,7 @@
                                         <ul id="toc">
                                             {% for h2 in page.toc -%}
                                                 <li><a href="
-                                                        {{ h2.permalink | safe }}{{ _ugly_url }}">{{ h2.title }}</a>
+                                                        {{ h2.permalink | safe }}">{{ h2.title }}</a>
                                                     {% if h2.children -%}
                                                         <ul>
                                                             {% for h3 in h2.children -%}

--- a/templates/index.html
+++ b/templates/index.html
@@ -94,7 +94,15 @@
                                     {% endfor -%}
 
                                     {# Output headers if above threshold #}
-                                    {% if header_count > config.extra.easydocs_heading_threshold -%}
+                                    {% if not config.extra.easydocs_heading_threshold -%}
+                                        {# Undefined or 0 unable to find a way to differnciate between 0 and undefined.
+                                         1 is already including any headings so is not 0 not needed #}
+                                        {% set _threshold = 5 -%}
+                                    {% else %}
+                                        {% set _threshold = config.extra.easydocs_heading_threshold -%}
+                                    {% endif -%}
+
+                                    {% if header_count >= _threshold -%}
                                         <ul id="toc">
                                             {% for h2 in page.toc -%}
                                                 <li><a href="

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
 {% endif -%}
 <main>
     {# Create variable to allow appending index.html at end of links if set in config #}
-    {% if not config.extra.easydocs_uglyurls or config.mode == "Serve" -%}
+    {% if not config.extra.easydocs_uglyurls or config.mode == "serve" -%}
         {% set _ugly_url = "" -%}
     {% else %}
         {% set _ugly_url = "index.html" -%}


### PR DESCRIPTION
Wanted a way to be able to see what headings are available on a page quickly and needed it to work even if I only had 1 or two as the page might be long and the 2nd one is very far down. This change was implemented to be backward compatible with existing websites.

In addition:
- Seem to have made an error when doing the last fix. Was trying to use it today and realized that it wasn't working. I appeared to have put a capital S in error at some point. Not sure how that happened (auto-correct?)
- Found one more place that ugly url was being used in the toc for a page in the nav and removed it as it does not provide value there after the anchor. 