### PR TITLE
Older versions of zola serve are capitalized

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
 {% endif -%}
 <main>
     {# Create variable to allow appending index.html at end of links if set in config #}
-    {% if not config.extra.easydocs_uglyurls or config.mode == "serve" -%}
+    {% if not config.extra.easydocs_uglyurls or config.mode == "serve" or config.mode == "Serve" -%}
         {% set _ugly_url = "" -%}
     {% else %}
         {% set _ugly_url = "index.html" -%}


### PR DESCRIPTION
- Found out that I didn't make a mistake but that older versions of zola do have a capital "S" in serve. So modfied to support either version.