### PR TITLE
fix section.word_count is not a number

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -147,11 +147,13 @@
 
         <div id="wrap">
             {% block content -%}
+              {%- if section.word_count -%}
                 {%- if section.word_count > 0 -%}
                     {{ section.content |safe }}
                 {%- else -%}
                     {%- include "sec_toc_2_level.html" -%}
                 {% endif -%}
+              {% endif %}
             {% endblock content %}
         </div>
 


### PR DESCRIPTION
I was trying to setup the theme in a blank installation and found the error in `template/index.html` that `section.word_count` is not a number

If it helps I propose this change

Steps to reproduce the error

```
zola init name
cd themes
git clone https://github.com/codeandmedia/zola_easydocs_theme
```

Set theme name in global `config.toml` in first section vars

```
# The site theme to use.
theme = "zola_easydocs_theme"
```

Then run 

```
zola serve
```

And the error  appears