### PR TITLE
Restore Table of contents when top level section is empty

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -147,13 +147,11 @@
 
         <div id="wrap">
             {% block content -%}
-              {%- if section.word_count -%}
-                {%- if section.word_count > 0 -%}
+                {%- if section.word_count -%}
                     {{ section.content |safe }}
                 {%- else -%}
                     {%- include "sec_toc_2_level.html" -%}
                 {% endif -%}
-              {% endif %}
             {% endblock content %}
         </div>
 


### PR DESCRIPTION
Fix the if condition so that it accounts for where there are no sections and still shows the table of contents when there is no content or no top level section